### PR TITLE
Revise and extend contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,16 @@ All contributors are expected to abide by the [QC-Devs Code of Conduct](CODE_OF_
 
 Contributions to QC-Devs packages are made through GitHub.
 If you are not familiar with Git or GitHub,
-we recommend that you take a look at the [GitHub guides] or this [Git book].
-The gamified [Learn Git Branching] is a fun way
-to learn the basics of the `git` command in an interactive and visual way.
+we encourage you to explore some of the online documentation and tutorials:
 
-[GitHub Guides]: https://guides.github.com/
-[Git Book]: https://git-scm.com/book/en/v2
-[Learn Git Branching]: https://learngitbranching.js.org/
+- The [GitHub guides](https://guides.github.com/) describe Git and GitHub in detail.
+  It provides reading material and documentation to help you become familiar with all the relevant concepts.
+- The [Git book](https://git-scm.com/book/en/v2) focuses on the Git program itself
+  and discusses various online providers, including GitHub,
+- The gamified [Learn Git Branching](https://learngitbranching.js.org/) is a fun way,
+  to learn the basics of the `git` command in an interactive and visual way.
+- The [GitHub Skills](https://skills.github.com/) courses
+  provide online, interactive, GitHub tutorials.
 
 
 ### Configure Git and GitHub
@@ -41,9 +44,11 @@ and let the maintainers know that you are working on it by assigning yourself.
 Also use the issue to plan your changes.
 Try to solve only one problem at a time,
 rather than fixing multiple problems and adding several features at once.
+For example, see the [IOData issue on refactoring the continuous integration], which has been addressed in many pull requests.
 
 [issue]: https://docs.github.com/en/issues
 [assign yourself]: https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users
+[IOData issue on refactoring the continuous integration]: https://github.com/theochem/iodata/issues/313
 
 
 ### Development Setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,49 +1,148 @@
 # QC-Devs Contributing Guidelines
 
-Welcome to the **QC-Devs** community! We are excited to have you here. In order to make your contribution process as smooth, efficient, and inclusive as possible, we have created these guidelines. All contributors are expected to abide by the [QC-Devs Code of Conduct](CODE_OF_CONDUCT.md).
+Welcome to the **QC-Devs** community!
+We are excited to have you here.
+In order to make your contribution process as smooth, efficient, and inclusive as possible,
+we have created these guidelines.
+All contributors are expected to abide by the [QC-Devs Code of Conduct](CODE_OF_CONDUCT.md).
 
-## GitHub Workflow
-All contributions to QC-Devs packages are made through GitHub. If you are not familiar with git or GitHub, we recommend you to take a look at the [GitHub Guides](https://guides.github.com/) or this [git book](https://git-scm.com/book/en/v2).
 
-To ensure clarity and effective collaboration, please follow these steps:
+## Working with Git and GitHub
 
-#### Issue Management
-Before starting to work on a contribution, please check the issues of the project you want to contribute to.
-- If your contribution will solve an existing issue, please [assign yourself](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users) to the issue and let the maintainers know that you are working on it. If you plan to add a new feature, please create a new issue and let the maintainers know that you are working on it (assign yourself to the issue).
-- Contributions or [pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) (PR) should be short and focused (shorter PRs are easier to review and check for errors). One PR should solve one issue (or even part of one) or add just one feature. This makes the review process faster and easier for everyone.
+Contributions to QC-Devs packages are made through GitHub.
+If you are not familiar with Git or GitHub,
+we recommend that you take a look at the [GitHub guides] or this [Git book].
+The gamified [Learn Git Branching] is a fun way
+to learn the basics of the `git` command in an interactive and visual way.
 
-#### Contribution Workflow
-Here is a brief overview of QC-Devs contributing workflow:
-    1. [Fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) the repository
-    2. Create a new branch
-    3. Make your changes
-    4. Push your changes to your fork
-    5. [Create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) to the `main` branch of the original repository. The PR should have a clear title and description (of what it does and how), and should reference the issue it solves (if it solves an issue). It's much easier to review several small pull requests than one gargantuan one, so it is preferable to make small pull requests as you go along.
+[GitHub Guides]: https://guides.github.com/
+[Git Book]: https://git-scm.com/book/en/v2
+[Learn Git Branching]: https://learngitbranching.js.org/
 
-#### Commit Messages
-We follow the [Pansini guide](https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53#rules-for-a-great-git-commit-message-style) style for commit messages. This makes it easier to generate changelogs and to understand the history of the project.
 
-## Code Contributions
-Code contributions are the most common type of contribution. We welcome all types of code contributions, including bug fixes, new features, and documentation updates. All code contributions should follow the guidelines below.
+### Configure Git and GitHub
+
+Your Git and GitHub configuration ensures that your contributions are properly attributed
+and that your local `git` commands can easily communicate with GitHub.
+You can find step-by-step instructions in our
+[Git and GitHub Configuration](contributing/config.md) guide.
+
+
+### Issue Management
+
+Before starting to work on a contribution,
+please check the issues of the project you want to contribute to.
+
+If your contribution will solve an existing [issue],
+please [assign yourself] to the issue and let the maintainers know that you are working on it.
+If you plan to add a new feature, please create a new issue
+and let the maintainers know that you are working on it by assigning yourself.
+
+Also use the issue to plan your changes.
+Try to solve only one problem at a time,
+rather than fixing multiple problems and adding several features at once.
+
+[issue]: https://docs.github.com/en/issues
+[assign yourself]: https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users
+
+
+### Development Setup
+
+Setting up a local development environment can be summarized as follows
+(only needed once per repo):
+
+- [Fork] the repository on GitHub.
+- Clone the original repository on your local machine.
+- Add your fork as a second remote to the local clone of the repository.
+- Set up the software environment in your local clone.
+
+Detailed instructions with copy-pasteable commands can be found in our
+[Development Setup](contributing/development_setup.md) guide.
+
+[Fork]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
+
+
+### Contribution Workflow
+
+A contributions is made in the form of a [pull requests] (PR),
+in which you propose a set of changes to the source code.
+A PR should be small and focused:
+Fix one issue (or even part of one) or add just one feature.
+This makes the review process faster and easier for everyone.
+
+[pull requests]: https://docs.github.com/en/pull-requests
+
+The contribution workflow involves steps on your local and online repositories.
+It can be summarized as follows:
+
+1. Create a new branch in your local clone of the repository.
+2. Make your changes and commit them locally.
+3. Push your new branch with the changes to your fork on GitHub.
+4. [Create a pull request] to the `main` branch of the original repository.
+
+Detailed instructions with copy-pasteable commands can be found in our
+[Contribution workflow](contributing/workflow.md) guide.
+
+[Create a pull request]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+
+
+## Code Quality
+
+Code contributions are the most common type of contribution.
+We welcome all types of code contributions, including bug fixes, new features, and documentation updates.
+All code contributions should follow the guidelines below.
+
 
 #### 1. Code should be well-written.
-In general, we follow the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide for Python code (using tools like [pycodestyle](https://pycodestyle.pycqa.org/en/latest/) and [pydocstyle](https://www.pydocstyle.org/en/stable/) can help ensure the quality of your code). We also use [Black](https://black.readthedocs.io/en/stable/) to format our code. Please make sure to run Black on your code before submitting a pull request.
-``` black -l 100 your_file.py ```
+
+In general, we follow the [PEP 8](https://peps.python.org/pep-0008/) style guide for Python code.
+Most of the style conventions are taken care of by pre-commit.
+If you have it installed as described above, the basics are covered.
+
+To improve the readability of changes on GitHub or in `git diff` output,
+use [semantic line breaks](https://sembr.org/) to wrap long sentences.
+
+We strive to write compact and elegant Python code.
+The linters configured in pre-commit can only detect or fix local style issues.
+Anything beyon the scope of the linters, will be addressed when reviewing a pull request.
+
 
 #### 2. Code should be well-documented.
-- All functions and classes (except tests) should have a docstring that explains what they do and how to use them.
+
+- All functions and classes (except tests) should have a docstring
+  that explain what they do and how to use them.
 - We encourage the use of mathematical equations in docstrings, using LaTeX notation.
-- We do not encourage the use of example code in docstrings, as it can become outdated and difficult to maintain. Instead, we encourage the use of Jupyter Notebooks for examples and tutorials.
+- We do not encourage the use of example code in docstrings,
+  as it can become outdated and difficult to maintain.
+  Instead, we encourage the use of Python scripts or Jupyter Notebooks for examples and tutorials.
 - Use `type hinting` to document the types of function (and method) arguments and return values.
-- Your code will be read by other developers, so it should be easy to understand. When a part of the code seems complex, it should have comments explaining what it does. (If in doubt, add a comment!)
+- Your code will be read by other developers, so it should be easy to understand.
+  If a piece of code seems complex, it should have comments explaining what it does.
+  (When in doubt, add a comment!)
+  Good comments emphasize the intent of the code, rather than literally describing it.
+
 
 #### 3. Code should be tested.
-- All code should be tested. We use [pytest](https://docs.pytest.org/en/stable/) for testing. When you add new code, you should also add tests for it. If you fix a bug, you should also add a test that fails without your code and passes with your code.
-- We use [codecov](https://codecov.io/) in most of our packages to check the code coverage of our tests. Please make sure that your code is well-tested and that the coverage does not decrease.
+
+- All code should be tested. We use [pytest](https://docs.pytest.org/en/stable/) for testing.
+  When you add new code, you should also add tests for it.
+  If you fix a bug, you should also add a test that fails without your code and passes with your code.
+- We use [codecov](https://codecov.io/) in most of our packages to check the code coverage of our tests.
+  Please make sure that your code is well-tested and that the coverage does not decrease.
+
 
 #### 4. Code should be consistent.
-Code needs to be consistent with the rest of the codebase. This makes it easier to review and maintain. This includes:
-- Variable names, function names, and class names should be consistent with the rest of the codebase. Most QC-Devs repositories use [atomic units](https://en.wikipedia.org/wiki/Atomic_units) internally. We ask that you try to preserve this (for consistency), but still document units.
-- Even more, variable names should be consistent with all QC-Devs packages. We are in the process of making a glossary but at the moment, please take a look at the existing code on [GitHub](https://github.com/theochem) and try to match them.
 
-We value your contributions and appreciate your efforts to improve QC-Devs packages. By following these guidelines, you can ensure smoother collaboration and enhance the overall quality of the project.
+Code needs to be consistent with the rest of the codebase.
+This makes it easier to review and maintain. This includes:
+
+- Variable names, function names, and class names should be consistent with the rest of the codebase.
+  Most QC-Devs repositories use [atomic units](https://en.wikipedia.org/wiki/Atomic_units) internally.
+  We ask that you try to preserve this (for consistency), but still document units.
+
+- Even more, variable names should be consistent across all QC-Devs packages.
+  We are in the process of creating a glossary, but for now,
+  please take a look at the existing code on [GitHub](https://github.com/theochem) and try to match them.
+
+We value your contributions and appreciate your efforts to improve QC-Devs packages.
+By following these guidelines, you can ensure smoother collaboration and enhance the overall quality of the project.

--- a/contributing/config.md
+++ b/contributing/config.md
@@ -1,0 +1,74 @@
+# Git and GitHub configuration
+
+- If you don't already have an SSH key pair, create one using the following terminal command:
+
+    ```bash
+    ssh-keygen -t rsa -b 4096 -C "your_email@example.com" -f "${HOME}/.ssh/id_rsa_github_com"
+    ```
+
+    An empty passphrase is convenient and should be fine.
+    This will generate a private and a public key in `${HOME}/.ssh`.
+
+- Upload your *public* SSH key to https://github.com/settings/keys.
+  This is a single long line in `${HOME}/.ssh/id_rsa_github_com.pub`,
+  which you can copy and paste into the settings page in your browser.
+
+- Configure SSH on you computer to use this key pair for authentication
+  when pushing branches to GitHub.
+  Add the following to your `.ssh/config` file:
+
+    ```
+    # Do not allow SSH to try all keys, as SSH servers only accept a few attempts.
+    # Keys must be specified for each host.
+    IdentitiesOnly yes
+
+    Host github.com
+        Hostname github.com
+        ForwardX11 no
+        IdentityFile %d/.ssh/id_rsa_github_com
+    ```
+
+    (Make sure you have the correct name for the *private* key file.)
+
+- Configure Git and to use the name and email address associated with your GitHub account, by running the following commands:
+
+    ```
+    git config --global user.name "Your Name"
+    git config --global user.email "youremail@yourdomain.com"
+    ```
+
+    Use your real name.
+    Take the same e-mail address that you use for your (academic) affiliation.
+    (You can configure your GitHub account to recognize multiple e-mail addresses.)
+
+- Optionally, you can set more convenient defaults:
+
+    - The default text editor for commit messages can be set to `nano` as follows:
+
+        ```
+        git config --global core.editor nano
+        ```
+
+    - There are several tools to make the output of `git diff` more readable,
+      such as: [difftastic], [diffr] or [delta].
+
+    - You can change the bash prompt to summarize the current state of the Git repository.
+      This instant visual feedback, makes working with Git much more intuitive.
+      There are many popular options out there:
+
+      - [powerline], [liquidprompt], [starship] and [ohmyposh] are among the most fancy ones,
+        but they have non-bash dependencies that make them a bit harder to install.
+
+      - [powerbash] and [pureline] are pure shell implementations,
+        which makes them a bit easier to set up.
+
+[difftastic]: https://github.com/Wilfred/difftastic
+[diffr]: https://github.com/mookid/diffr
+[delta]: https://dandavison.github.io/delta/
+[powerline]: https://github.com/powerline/powerline
+[powerbash]: https://github.com/tovrstra/powerbash/tree/merged1
+[starship]: https://github.com/starship/starship
+[ohmyposh]: https://ohmyposh.dev/
+[liquidprompt]: https://liquidprompt.readthedocs.io/
+[gitstatus]: https://github.com/romkatv/gitstatus
+[pureline]: https://github.com/chris-marsh/pureline

--- a/contributing/development_setup.md
+++ b/contributing/development_setup.md
@@ -1,0 +1,87 @@
+# Development setup
+
+> :warning:
+> The comments below are written for the [iodata] repository.
+> You can replace the `iodata` substring with a different repository name.
+
+> :warning:
+> It is assumed that you have [Git], [Python] >=3.9 and [pre-commit] installed on your computer.
+
+1. Create a [fork] of the repository on GitHub.
+   This is essentially your online copy of the repository where you can draft your changes.
+
+[fork]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
+
+2. Create a local clone of the original Git repository and enter the directory of the clone:
+
+    ```bash
+    git clone git@github.com:theochem/iodata.git
+    cd iodata
+    ```
+
+3. Configure your fork as the second remote repository
+   (in addition `origin` which was created in the previous step and refers on `theochem`):
+
+    ```bash
+    git remote add mine git@github.com:${your-github-account}/iodata.git
+    ```
+
+    where you replace `${your-github-account}` with your actual account name on GitHub.
+
+4. Create a software environment that is suitable for development.
+   (Feel free to adapt it to your personal preferences.
+   For example, you can replace `python` with `python3.11` on Ubuntu 22
+   to work with a newer Python version.)
+
+    ```bash
+    python -m venv venv
+    source venv/bin/activate
+    pip install -e .[dev]
+    pre-commit install
+    ```
+
+You now have a Python virtual environment with the development version of the repository installed.
+In this environment, you can
+run specific unit tests you are working on,
+build the documentation, or
+experiment with the package as it would be installed in a production environment.
+
+There are a few additional steps you can take to fine-tune your setup:
+
+- The manual activation of the virtual environment with `source venv/bin/activate`
+  has to be repeated every time you open a new terminal window, which is impractical.
+  Some IDEs, like VSCode, will do this when you open a terminal inside the IDE.
+
+    We do not recommend adding the `source` line to your `~/.bashrc`, `~/.bash_profile`,
+    or other global recourse configuration file.
+    Instead, you can use [direnv] to configure the venv locally in the `iodata/` directory.
+    After installing and setting up direnv, run the following two commands in `iodata/`:
+
+    ```bash
+    echo 'source venv/bin/activate' > .envrc
+    direnv allow
+    ```
+
+    Now, the virtual environment will be activated whenever you change to the `iodata/` directory.
+
+- The line `pre-commit install` will enable pre-commit in your local clone of the repository.
+  This step is important because it automatically cleans up changes
+  *before* they are committed to the repository.
+
+  If you ever make a second clone of the repository,
+  you will need to run `pre-commit install` again in the new clone.
+
+- QC-Devs repositories come with an `.editorconfig` file.
+  This file contains some basic editor settings
+  and is supported by most popular text editors and IDEs.
+  See [editorconfig.org] for details.
+  By including this file in the repository,
+  we ensure a certain level of consistency across all contributions.
+  Some IDEs, such as VSCode, require you to install a plugin to enable editorconfig support.
+
+[iodata]: https://github.com/theochem/iodata
+[Git]: https://git-scm.com/some
+[Python]: https://www.python.org/
+[pre-commit]: https://pre-commit.com/
+[direnv]: https://direnv.net/
+[editorconfig.org]: https://editorconfig.org/

--- a/contributing/workflow.md
+++ b/contributing/workflow.md
@@ -1,0 +1,91 @@
+# Contribution Workflow
+
+The steps below assume that you have
+[set up your local development environment](development_setup.md)
+and [configured Git and GitHub](config.md).
+It also assumes that you have
+[discussed the planned changes in a GitHub issue](../CONTRIBUTING.md#issue-management).
+Here, we will only go over the technicalities of creating a pull request.
+
+1. Unless you just created a fork, you need to update the local main branch
+   by *pulling* the latest commits from the original repository.
+   Assuming you have no uncommitted changes, this can be done with the following commands:
+
+    ```bash
+    git checkout main
+    git pull
+    ```
+
+
+2. Create a new branch, with a name that indicates the purpose of your change:
+
+    ```bash
+    git checkout -b new-feature
+    ```
+
+    (Take something more descriptive than `new-feature`.)
+
+3. Make changes to the source code.
+   To make these easier to process and to maintain the code quality,
+   general recommendations can be found in the
+   [Code Quality section of the main Contributing Guide](../CONTRIBUTING.md#code-quality).
+
+
+4. Verify that all the tests pass and that the documentation builds without warnings or errors.
+   The exact commands for these tests will be slightly different in each repository.
+   See the `CONTRIBUTING.md` file in the forked repository for more details.
+
+5. Commit your changes to your `new-feature` branch.
+   This step is the most tecnically challenging.
+   Providing a few copy-pasteable commands here would be misleading,
+   because you often need to adapt them to your specific situation.
+
+   Roughly speaking, you run the following commands:
+
+   - `git status` and `git diff` to assess the status of your local files.
+   - `git add` to select the files with changes that you want to include in the commit.
+   - `git commit` to actually create the commit.
+
+   If you want to commit all changes, run `git commit -a`.
+   (You will still need to `git add` new files.)
+
+   You will notice that `pre-commit` checks for and possibly fixes minor problems.
+   If it finds something (even if it is automatically fixed), it will abort the commit.
+   This gives you a chance to fix those problems or check the automatic fixes first.
+   When you are happy with all the cleanup, run `git add` and `git commit` again.
+
+   When prompted, write a meaningful commit message.
+   The first line is a short summary, written in the imperative mood.
+   Optionally, this can be followed by a blank line and a longer description.
+
+   Some repositories follow the [Pansini style] for commit messages,
+   in order to derive changelogs and to make the history of the project easier to understand.
+
+[Pansini style]: https://gist.github.com/robertpainsi/b632364184e70900af4ab688decf6f53#rules-for-a-great-git-commit-message-style
+
+
+6. Push your branch to your forked repository on GitHub:
+
+    ```bash
+    git push mine -u new-feature
+    ```
+
+    A link should appear in the terminal that will take you to the next step.
+
+
+7. Make a pull request (PR) from your `new-feature` branch in your forked repository
+   to the `main` branch in the original repository.
+
+   The PR should have a clear title and description (of what it does and how).
+   If it fixes a specific issue,
+   it should reference that issue in the description (not title) with a line like `Fixes #123`,
+   where 123 is the issue number.
+
+   It's much easier to review several small pull requests than one gargantuan one,
+   so it is preferable to make small pull requests as you go along.
+
+
+8. Wait for the GitHub Actions to complete.
+   These should pass.
+   If not, you are encouraged to fix the reported problems by committing and pushing more changes.
+   Typically, someone should review your pull request within a few days or weeks.


### PR DESCRIPTION
Fixes #2

This integrates all the general parts of the contributing guide from the IOData repository. I've revised both the file we had here and the ones on IOData, and tried to improve them where possible.

For review, just reading the new version may be more practical than going through the diff: https://github.com/theochem/.github/blob/contrib-guide-update/CONTRIBUTING.md